### PR TITLE
Fix : Home화면, userReducer, userLogin 타입스크립트로 변환

### DIFF
--- a/FE/laams/src/Components/Common/Router.jsx
+++ b/FE/laams/src/Components/Common/Router.jsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes,Route } from 'react-router-dom';
-import Home from "../Home/Home.jsx"
+import Home from "../Home/Home.tsx"
 import DirectorHome from "../Director/Home/DirectorHome.jsx"
 import PrivateRoute from './PrivateRoute.jsx';
 import PublicRoute from './PublicRoute.jsx';

--- a/FE/laams/src/Components/Home/Home.tsx
+++ b/FE/laams/src/Components/Home/Home.tsx
@@ -2,18 +2,19 @@ import React, { useCallback, useEffect, useState } from 'react'
 import useLogin from '../../Hook/useLogin'
 import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { RootState } from '../../models/ReduxRootState';
 
-const Home = () => {
+const Home:React.FC = () => {
   const [loginData,] = useState({id:localStorage.getItem("id")? localStorage.getItem("id") : "", password:"", authority:"ROLE_DIRECTOR"});
   const [isChecked, setChecked] = useState(localStorage.getItem("id")? true : false); 
   const [, login] = useLogin();
-  const user = useSelector(state=>state.User);
+  const user = useSelector((state :RootState)=>state.User);
   const navigate = useNavigate();
-  const isLogin = useSelector(state=>state.User.accessToken);
+  const isLogin = useSelector((state :RootState)=>state.User.accessToken);
 
   // TODO: id, password 확인 및 로그인
   const loginButtonClick = useCallback(() => {
-    if(loginData["id"] === ""){
+    if(!loginData["id"] || loginData["id"] === ""){
       alert("아이디를 입력해 주세요");
       return
     }
@@ -60,7 +61,7 @@ const Home = () => {
               <input 
                 className='login-input'
                 placeholder='ID'
-                defaultValue={loginData['id']}
+                defaultValue={loginData['id']? loginData["id"]:""}
                 onChange={e=>{
                   loginData['id'] = e.target.value
                 }}

--- a/FE/laams/src/Hook/useLogin.ts
+++ b/FE/laams/src/Hook/useLogin.ts
@@ -3,11 +3,13 @@ import {setAccessToken,setAccessTokenExpireTime,setAuthority, setMemberId} from 
 import axios from 'axios';
 import { useDispatch } from 'react-redux';
 
-const useLogin = ()=> {
+type loginType = (id : string,password : string,isChecked:boolean) => void
+
+const useLogin = () :[boolean,loginType]=> {
   const [isLogin,setIsLogin] = useState(false);
   const dispatch = useDispatch();
 
-  const login = useCallback((id,password,isChecked)=>{
+  const login :loginType= useCallback((id : string,password : string,isChecked:boolean)=>{
     axios.post(`${process.env.REACT_APP_SPRING_URL}/api/v1/member/login`,{id,pw :password})
       .then( ({data})=>{
         if(isChecked){

--- a/FE/laams/src/models/ReduxRootState.ts
+++ b/FE/laams/src/models/ReduxRootState.ts
@@ -1,10 +1,10 @@
 
 export interface RootState {
     User: {
-      accessToken: string | null;
-      accessTokenExpireTime: string | null;
-      authority: string | null;
-      memberId: string | null;
-      userClear: boolean | null;
+      accessToken: string;
+      accessTokenExpireTime: string;
+      authority: string;
+      memberId: string;
+      userClear: boolean;
     };
   }

--- a/FE/laams/src/models/ReduxRootState.ts
+++ b/FE/laams/src/models/ReduxRootState.ts
@@ -1,0 +1,10 @@
+
+export interface RootState {
+    User: {
+      accessToken: string | null;
+      accessTokenExpireTime: string | null;
+      authority: string | null;
+      memberId: string | null;
+      userClear: boolean | null;
+    };
+  }

--- a/FE/laams/src/redux/reducer/userReducer.ts
+++ b/FE/laams/src/redux/reducer/userReducer.ts
@@ -6,7 +6,9 @@ const init = {
   memberId:null
 };
 
-const userReducer = (state = init, action)=>{
+
+
+const userReducer = (state = init, action: { type: string; payload: string | null | boolean; })=>{
   switch (action.type) {
     case "accessToken":
       return { ...state, accessToken: action.payload};

--- a/FE/laams/src/redux/reducer/userReducer.ts
+++ b/FE/laams/src/redux/reducer/userReducer.ts
@@ -8,7 +8,7 @@ const init = {
 
 
 
-const userReducer = (state = init, action: { type: string; payload: string | null | boolean; })=>{
+const userReducer = (state = init, action: { type: string; payload: string | boolean; })=>{
   switch (action.type) {
     case "accessToken":
       return { ...state, accessToken: action.payload};

--- a/FE/laams/tsconfig.json
+++ b/FE/laams/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext",
+      "es6"
+    ],
+    
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ],
+  "typeRoots": ["./src/types", "./node_modules/@types"]
+}


### PR DESCRIPTION
Home화면, userReducer, userLogin 타입스크립트로 변환하였습니다.
- 빨간 줄 에러 뜨는 것 중심으로 일단 고쳤습니다. 
- 일단 홈화면 로그인, 로그아웃 테스트와 localStorage 저장에는 문제가 없었습니다.
- 어디에 타입을 지정해줘야 하는지, 문법 대략 공부하긴 했는데 좀 어색한 것 같습니다. 
데이터 set할때 null을 넣기도 했었나...? 싶어서 이런 경우는 null을 넣어야 하나 헷갈렸습니다. (ex accessToken : null | srting ??) 특히 userReducer 부분 수정과 ReduxRooteState 이게 맞는 건지 헷갈리네요. 
- tsconfig는 임의로 참고해서 넣었습니다.